### PR TITLE
Update matching player process

### DIFF
--- a/chessxone-backend/sockets/controllers/user.js
+++ b/chessxone-backend/sockets/controllers/user.js
@@ -139,16 +139,16 @@ const requestGame = async (hosterID, guestID) => {
         await UserGamesInvitationsOnRedis.push(guestID, hosterID)
         await UserOnRedis.setIsLocked(hosterID, true);
 
-        const friendToNotifyGameCancled = await UserGamesInvitationsOnRedis.get(hosterID)
+        const playerToNotifyGameCancled = await UserGamesInvitationsOnRedis.get(hosterID)
 
-        if (friendToNotifyGameCancled) {
+        if (playerToNotifyGameCancled) {
             UserGamesInvitationsOnRedis.clear(hosterID)
-            for (let i = 0; i < friendToNotifyGameCancled.length; i++) {
-                await UserGameRequestOnRedis.clear(friendToNotifyGameCancled[i])
+            for (let i = 0; i < playerToNotifyGameCancled.length; i++) {
+                await UserGameRequestOnRedis.clear(playerToNotifyGameCancled[i])
             }
         }
 
-        return friendToNotifyGameCancled;
+        return playerToNotifyGameCancled;
 
     } catch (error) {
         return error;
@@ -160,16 +160,16 @@ const prepareCreateGame = async (guestID, hosterID) => {
         await UserGameRequestOnRedis.clear(hosterID)
         await UserOnRedis.setIsLocked(guestID, true);
 
-        const friendToNotifyGameCancled = await UserGamesInvitationsOnRedis.get(guestID)
+        const playerToNotifyGameCancled = await UserGamesInvitationsOnRedis.get(guestID)
 
-        if (friendToNotifyGameCancled) {
+        if (playerToNotifyGameCancled) {
             UserGamesInvitationsOnRedis.clear(guestID)
-            for (let i = 0; i < friendToNotifyGameCancled.length; i++) {
-                await UserGameRequestOnRedis.clear(friendToNotifyGameCancled[i])
+            for (let i = 0; i < playerToNotifyGameCancled.length; i++) {
+                await UserGameRequestOnRedis.clear(playerToNotifyGameCancled[i])
             }
         }
 
-        return friendToNotifyGameCancled;
+        return playerToNotifyGameCancled;
     } catch (error) {
         return error;
     }

--- a/chessxone-backend/sockets/eventEmitter.js
+++ b/chessxone-backend/sockets/eventEmitter.js
@@ -2,7 +2,7 @@ const io = require('../config/socketIO-instance');
 
 /*  General Events */
 
-const nofityAllconnectedFriends = async (connectedFriends, userData, Event = 'friend_changed_status') => {
+const nofityAllconnectedFriends = async (connectedFriends, userData, event = 'friend_changed_status') => {
     try {
         for (let i = 0; i < connectedFriends.length; i++) {
             const friendID = connectedFriends[i]._id.toString();

--- a/chessxone-frontend/components/Home/helpers/Browse.js
+++ b/chessxone-frontend/components/Home/helpers/Browse.js
@@ -4,37 +4,49 @@ import styles from '../home.module.css';
 import fetchApi from '../../../utils/apiFetch'
 import Skeleton from '../../UI/Skeleton';
 import { userContext } from '../../../store/user/context';
+import { USER_GAME_REQUEST_SUCCESS } from '../../../store/user/actions';
 
 const Browse = ({ userID }) => {
     const [suggestedUsersId, setSuggestedUsersId] = useState([])
-    const { state: { user: { incomingRequests = [], outgoingRequests = [] },connectedFriends } } = useContext(userContext);
+    const { dispatch, state: { user: { incomingRequests = [], outgoingRequests = [] },connectedFriends } } = useContext(userContext);
 
     useEffect(() => {
         const fetchFeed = async () => {
             try {
                 const { data } = await fetchApi.get({ url: `/users/${userID}/feed` })
                 const { lastConnectedUsers, connections } = data;
-
-                let filtredList = lastConnectedUsers.filter((ele) => !connections.includes(ele))
-                setSuggestedUsersId(filtredList.filter((connectionID) => connectionID !== userID))
+                // we will no longer filter By Non connection based to suggest player.
+                // let filtredList = lastConnectedUsers.filter((ele) => !connections.includes(ele))
+                // setSuggestedUsersId(filtredList.filter((connectionID) => connectionID !== userID))
+                setSuggestedUsersId(lastConnectedUsers.filter((connectionID) => connectionID !== userID))
             } catch (error) {
             }
         }
         fetchFeed()
     }, [])
 
-    useEffect(() => {
-        setSuggestedUsersId(suggestedUsersId.filter((connectionID) => connectedFriends.findIndex((ele) => (ele._id === connectionID)) === -1))
-    },[connectedFriends])
+    /* TO DELETE */
+    /* Filtring suggested player with be BY UserGameRequest UserGameInvitations */
+    // useEffect(() => {
+    //     setSuggestedUsersId(suggestedUsersId.filter((connectionID) => connectedFriends.findIndex((ele) => (ele._id === connectionID)) === -1))
+    // },[connectedFriends])
 
-    useEffect(() => {
-        setSuggestedUsersId(suggestedUsersId.filter((connectionID) => incomingRequests.findIndex((ele) => (ele._id === connectionID)) === -1))
-    },[incomingRequests])
+    // useEffect(() => {
+    //     setSuggestedUsersId(suggestedUsersId.filter((connectionID) => incomingRequests.findIndex((ele) => (ele._id === connectionID)) === -1))
+    // },[incomingRequests])
 
-    useEffect(() => {
-        setSuggestedUsersId(suggestedUsersId.filter((connectionID) => outgoingRequests.findIndex((ele) => (ele._id === connectionID)) === -1))
-    },[outgoingRequests])
+    // useEffect(() => {
+    //     setSuggestedUsersId(suggestedUsersId.filter((connectionID) => outgoingRequests.findIndex((ele) => (ele._id === connectionID)) === -1))
+    // },[outgoingRequests])
 
+    /* 
+    -----------------------------
+    instead of requesting connection
+    the player will ask for a match
+    once the players are matched and start playing 
+    they will be able to request a connection
+    -------------------------------
+    
     const handleRequestConnection = async (friendID) => {
         try {
             await fetchApi.post({ url: `/users/${userID}/connection/requests`, data: { userID: friendID } })
@@ -43,13 +55,33 @@ const Browse = ({ userID }) => {
             console.log(error)
         }
     }
+    */
+
+    const handleRequestGame = async (playerID) => {
+        try {
+            await fetchApi.put({ url: `/user-game/${userID}/request`, data: { userID: playerID } });
+            setSuggestedUsersId(suggestedUsersId.filter((suggestedplayerID) => suggestedplayerID !== playerID))
+        } catch (error) {
+            throw  new Error('request game failed')
+        }
+
+    }
+
+    const handleRequestGameSuccess = (opponentData) => {
+        dispatch({ type: USER_GAME_REQUEST_SUCCESS, payload: opponentData });
+
+    }
 
     return (
         <div className={styles.suggested_player_container}>
             <p style={{color: 'var(--purple)'}}>suggested Players</p>
             <ul>
                 {suggestedUsersId.map((ele) => (
-                    <ConnectionItem key={ele} handleRequestConnection={handleRequestConnection} userID={ele} />
+                    <ConnectionItem 
+                    key={ele}
+                     handleRequestGame={handleRequestGame}
+                      userID={ele}
+                      handleRequestGameSuccess={handleRequestGameSuccess} />
                 ))}
             </ul>
         </div>
@@ -59,7 +91,7 @@ const Browse = ({ userID }) => {
 export default Browse
 
 
-const ConnectionItem = ({ userID, handleRequestConnection }) => {
+const ConnectionItem = ({ userID, handleRequestGame,handleRequestGameSuccess }) => {
     const [userInfo, setuserInfo] = useState(null)
     const [isLoading, setIsLoading] = useState(false);
     const [isRequesting, setIsRequesting] = useState(false)
@@ -68,7 +100,6 @@ const ConnectionItem = ({ userID, handleRequestConnection }) => {
         try {
             setIsLoading(true)
             const { data } = await fetchApi.get({ url: `/users/${userID}/user-info` })
-
             setuserInfo(data)
         } catch (error) {
         } finally {
@@ -84,17 +115,18 @@ const ConnectionItem = ({ userID, handleRequestConnection }) => {
         return (<li><Skeleton width="200px" height="160px" /></li>)
     }
 
-    const requestConnection = async () => {
+    const requestGame = async () => {
         try {
             setIsRequesting(true)
-            console.log('request connection')
-            await handleRequestConnection(userID)
-        } catch (error) {
+            await handleRequestGame(userID)
+            handleRequestGameSuccess(userInfo)
+        } catch (error) {            
         }
         finally {
             setIsRequesting(false)
         }
     }
+
     return (
         <li>
             <div style={{ display: "flex", alignItems: 'center' }}>
@@ -106,9 +138,9 @@ const ConnectionItem = ({ userID, handleRequestConnection }) => {
             <div>
                 <button
                     disabled={isRequesting}
-                    onClick={requestConnection}
+                    onClick={requestGame}
                     className={styles.secondary}>
-                    Request{isRequesting && 'ed'}
+                    {!isRequesting && 'Play'}
                     {isRequesting && <img src="/icon/loader.svg" height="15" width="15" />}
                 </button>
 

--- a/chessxone-frontend/components/Home/helpers/JoinGameRequesting.js
+++ b/chessxone-frontend/components/Home/helpers/JoinGameRequesting.js
@@ -15,7 +15,9 @@ const JoinGameRequesting = () => {
             const { data } = await fetchApi.get({ url: `/user-game/${userID}/invitations` })
             dispatch({ type: SET_USER_GAME_INVITATIONS, payload: { userGameInvitations: data } })
         } catch (error) {
-
+            throw new Error('get games invitations failed')
+        }finally{
+            return;
         }
     }
 
@@ -23,7 +25,9 @@ const JoinGameRequesting = () => {
         try {
             await fetchApi.put({ url: `/user-game/${userID}/accept`, data: { userID: friendID } });
         } catch (error) {
-            console.log('join game error')
+            throw new Error('join game failed')
+        }finally{
+            return;
         }
     }
 
@@ -35,8 +39,8 @@ const JoinGameRequesting = () => {
         <div className={styles.game_request_container}>
             <ul>
                 {userGameInvitations &&
-                    userGameInvitations.map((friendID) => (
-                        <FriendRequestingItem joinGame={() => { joinGame(friendID) }} key={friendID} friendID={friendID} userID={userID}
+                    userGameInvitations.map((opponentID) => (
+                        <FriendRequestingItem joinGame={() => { joinGame(opponentID) }} key={opponentID} opponentID={opponentID}
                         />))}
             </ul>
         </div>
@@ -46,18 +50,17 @@ const JoinGameRequesting = () => {
 export default JoinGameRequesting
 
 
-const FriendRequestingItem = ({ friendID, userID, joinGame, message = '' }) => {
+const FriendRequestingItem = ({ opponentID, joinGame, message = '' }) => {
     const [friendInfo, setFriendInfo] = useState(null)
     const [isLoading, setIsLoading] = useState(false);
 
     const getFriendInfo = async () => {
         try {
             setIsLoading(true)
-            const { data } = await fetchApi.get({ url: `/users/${userID}/friend-info/${friendID}` })
-
+            const { data } = await fetchApi.get({ url: `/users/${opponentID}/user-info/` })
             setFriendInfo(data)
         } catch (error) {
-            console.log('error*********',error.message)
+            
         } finally {
             setIsLoading(false)
         }
@@ -68,6 +71,7 @@ const FriendRequestingItem = ({ friendID, userID, joinGame, message = '' }) => {
     }, [])
 
     if (isLoading || !friendInfo) {
+        
         return (<li><Skeleton width="100%" height="160px" /></li>)
     }
 

--- a/chessxone-frontend/components/Home/helpers/WaitingOpponent.js
+++ b/chessxone-frontend/components/Home/helpers/WaitingOpponent.js
@@ -8,16 +8,15 @@ import { SET_USER_GAME_REQUEST } from '../../../store/user/actions';
 
 const WaitingOpponent = () => {
     const { dispatch, state: { user: { _id: userID }, userGameRequest } } = useContext(userContext);
-
+    
     const getUserGameRequest = async () => {
         try {
             const { data: { opponentID } } = await fetchApi.get({ url: `/user-game/${userID}/request` });
             if(opponentID){
-                const { data } = await fetchApi.get({ url: `/users/${userID}/friend-info/${opponentID}` })
+                const { data } = await fetchApi.get({ url: `/users/${opponentID}/user-info/` });
                 dispatch({ type: SET_USER_GAME_REQUEST, payload: { userGameRequest: data } });
             }
         } catch (error) {
-
         }
     }
 


### PR DESCRIPTION
Closes #3 
the players can invite / accept game request without been connections.

## Backend: 
- refactoring / renaming
- remove TTL for userGameRequest

## Frontend:
- fetch players Info not from connection EndPoint
- make it able to invite play from <Browse/> without been a connection.